### PR TITLE
pyobjc-framework-fsevents 8.2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyobjc-framework-FSEvents" %}
-{% set version = "7.3" %}
+{% set version = "8.2" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3d12df35cc0b18c3f7c677d6bc870a7ea13a5d1c2f16456c1f445e0b894ddb55
+  sha256: 35e175f157c2906f2fdaa0ddaa20f2505840801449c54638512d6a0b2f1bcccf
 
 build:
   number: 0


### PR DESCRIPTION
Update pyobjc-framework-fsevents to 8.2