### PR TITLE
pyobjc-framework-fsevents 8.5 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
-channels:
-    c3i_test2: pyobjc_dev
+#channels:
+#    c3i_test2: pyobjc_dev

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+channels:
+    c3i_test2: pyobjc_dev

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyobjc-framework-FSEvents" %}
-{% set version = "7.3" %}
+{% set version = "8.5" %}
 
 package:
   name: {{ name|lower }}
@@ -7,34 +7,40 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 3d12df35cc0b18c3f7c677d6bc870a7ea13a5d1c2f16456c1f445e0b894ddb55
+  sha256: 21928fd0d17ad69f45d41f89228b7446d8faf0d1bba0d71e8e23451196701004
 
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
-  skip: true  # [(not osx) or py2k]
+  skip: true  # [(not osx) or py<36]
 
 requirements:
   host:
     - pip
     - python
     - setuptools
+    - wheel
   run:
     - python
-    - pyobjc-core >=6.1
-    - pyobjc-framework-cocoa >=6.1
+    - pyobjc-core {{ version }}
+    - pyobjc-framework-cocoa {{ version }}
 
 test:
   imports:
     - FSEvents
+  requires:
+    - pip
+  commands:
+    - pip check
 
 about:
-  home: https://bitbucket.org/ronaldoussoren/pyobjc
+  home: https://github.com/ronaldoussoren/pyobjc
   license: MIT
   license_family: MIT
   license_file: LICENSE.txt
   summary: Wrappers for the framework FSEvents on macOS
-
+  dev_url: https://github.com/ronaldoussoren/pyobjc/tree/master/pyobjc-framework-FSEvents
+  doc_url: https://github.com/ronaldoussoren/pyobjc
 extra:
   recipe-maintainers:
     - xhochy


### PR DESCRIPTION
Changelog: https://github.com/ronaldoussoren/pyobjc/blob/v8.5/docs/changelog.rst and https://github.com/ronaldoussoren/pyobjc/releases
Requirements: https://github.com/ronaldoussoren/pyobjc/blob/v8.5/pyobjc-framework-FSEvents/setup.py

Actions:
1. Skip py<36
2. Add wheel in host
3. Add pip check
4. Add dev and doc urls
5. Fix home url

NOTE: Remove abs.yaml before merging