### PR TITLE
pyobjc-framework-fsevents 9.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
 build:
   number: 0
   script: {{ PYTHON }} -m pip install . -vv
-  skip: true  # [(not osx) or py<36]
+  skip: true  # [(not osx) or py<37]
 
 requirements:
   host:
@@ -39,6 +39,8 @@ about:
   license_family: MIT
   license_file: LICENSE.txt
   summary: Wrappers for the framework FSEvents on macOS
+  description: |
+    Wrappers for the framework FSEvents on macOS
   dev_url: https://github.com/ronaldoussoren/pyobjc/tree/master/pyobjc-framework-FSEvents
   doc_url: https://github.com/ronaldoussoren/pyobjc
 extra:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "pyobjc-framework-FSEvents" %}
-{% set version = "8.5" %}
+{% set version = "9.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: 21928fd0d17ad69f45d41f89228b7446d8faf0d1bba0d71e8e23451196701004
+  sha256: 3577e67ce41e9dae9eeb7b31c828b65a0234ab808f5b64779f27b0552ef5f265
 
 build:
   number: 0


### PR DESCRIPTION
**Jira ticket:** [PKG-819](https://anaconda.atlassian.net/browse/PKG-819) (pyobjc-framework-fsevents 9.0)

**The upstream data:**
Repo: https://github.com/ronaldoussoren/pyobjc/tree/master/pyobjc-framework-FSEvents
License: https://github.com/ronaldoussoren/pyobjc/blob/v9.0/pyobjc-framework-FSEvents/LICENSE.txt
Requirements:
- https://github.com/ronaldoussoren/pyobjc/blob/v9.0/pyobjc-framework-FSEvents/pyobjc_setup.py
- https://github.com/ronaldoussoren/pyobjc/blob/v9.0/pyobjc-framework-FSEvents/setup.py

**_Actions:_**

1. `Skip py<37`
2. Add a `description`


**Package's statistics**
<details>

 * Priority D | effort: easy | Category: other | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'osx-64', 'osx-arm64'
 * Latest version: 9.0
 * Release on PyPi:
    * version: 9.0
    * date: 2022-11-05T19:36:59
* [PyPi history](https://pypi.org/project/pyobjc-framework-fsevents/#history)
 * Popularity: 
    * 3 months downloads: 32597.0
    * All time:  25776 downloads -  pyobjc-framework-fsevents  9.0  Wrappers for the framework FSEvents on macOS  

</details>

**Other checks:**

<details>

3. - [x] https://github.com/ronaldoussoren/pyobjc is present
4. - [x] Check the pinnings
7. - [x] `dev_url` is present
    https://github.com/ronaldoussoren/pyobjc/tree/master/pyobjc-framework-FSEvents
8. - [x] `doc_url` is present
    https://github.com/ronaldoussoren/pyobjc
9. - [x] Verify that the `build_number` is correct
10. - [x] has `setuptools`
11. - [x] has `wheel`
12. - [x] `pip` in test
13. - [x] Verify the test section
14. - [x] Verify if the package is `architecture specific`
15. - [x] Verify that private modules are not mentioned in the recipe For example: (_private_module)
16.  - [x] license_file: LICENSE.txt is present
17. - [x] License: MIT
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier         |
|:-------------------|
| MIT                |
| MIT-0              |
| MIT-advertising    |
| MIT-CMU            |
| MIT-enna           |
| MIT-feh            |
| MIT-Modern-Variant |
| MIT-open-group     |
| MITNFA             |

18. - [x] license_family MIT is present
</details>



**Links:**
* [Anaconda Recipes feedstock](https://github.com/AnacondaRecipes/pyobjc-framework-fsevents-feedstock)
* [Update branch](https://github.com/AnacondaRecipes/pyobjc-framework-fsevents-feedstock/tree/9.0)
* [conda-forge recipe](https://github.com/{upstream}/{feedstock_name}-feedstock)
* [PyPI](https://pypi.org/project/pyobjc-framework-fsevents)
* [Diff between upstream and feature branch](https://github.com/conda-forge/pyobjc-framework-fsevents-feedstock/compare/main...AnacondaRecipes:9.0)
* [Diff between origin and feature branch](https://github.com/AnacondaRecipes/pyobjc-framework-fsevents-feedstock/compare/master...AnacondaRecipes:9.0)
* [The last merged PRs](https://github.com/AnacondaRecipes/pyobjc-framework-fsevents-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

**Updating the recipe:**
If the recipe needs additional modification the update branch can be modified. Note that the PR diffs are not updated with these changes.
```
git clone -b 9.0 git@github.com:AnacondaRecipes/pyobjc-framework-fsevents-feedstock.git
```


[PKG-819]: https://anaconda.atlassian.net/browse/PKG-819?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ